### PR TITLE
Flag added to face PMTs and PMT shields to center of detector

### DIFF
--- a/watchmakers/io_operations.py
+++ b/watchmakers/io_operations.py
@@ -1007,6 +1007,11 @@ def testEnabledCondition(arguments):
         additionalString += "_fidThickness_%f" %(float(arguments['--fidThick']))
         additionalCommands +=" --fidThick %f" %(float(arguments['--fidThick']))
 
+    if arguments['--pmtCtrPoint']:
+        additionalMacOpt += '/rat/db/set GEO[inner_pmts] orientation "point"'
+        additionaMacStr += "_pmtCtrPoint_"
+        additionalString += "_pmtCtrPoint_"
+
     if float(arguments['--U238_PPM'])!= defaultValues[baseValue+15]:
         additionalString += "_U238_PPM_%f" %(float(arguments['--U238_PPM']))
         additionalCommands +=" --U238_PPM %f" %(float(arguments['--U238_PPM']))

--- a/watchmakers/io_operations.py
+++ b/watchmakers/io_operations.py
@@ -1008,7 +1008,8 @@ def testEnabledCondition(arguments):
         additionalCommands +=" --fidThick %f" %(float(arguments['--fidThick']))
 
     if arguments['--pmtCtrPoint']:
-        additionalMacOpt += '/rat/db/set GEO[inner_pmts] orientation "point"'
+        additionalMacOpt += '/rat/db/set GEO[inner_pmts] orientation "point"\n'
+        additionalMacOpt += '/rat/db/set GEO[shield] orientation_inner "point"\n' 
         additionaMacStr += "_pmtCtrPoint_"
         additionalString += "_pmtCtrPoint_"
 

--- a/watchmakers/load.py
+++ b/watchmakers/load.py
@@ -84,6 +84,8 @@ docstring = """
     --steelThick=<StT>  Steel Thickness (mm)     [Default: %f]
     --fidThick=<fT>     Fiducial volume-> PMT Thickness (mm) [Default: %f]
 
+    --pmtCtrPoint       Point inner PMTs of Watchman geometry to detector center
+
     -M                  Merge result files from trial ntuples
 
     --efficiency        Read merged files and perform analysis


### PR DESCRIPTION
--pmtCtrPoint flag implemented for generating macros with PMT and PMT shields facing center of detector.  

Technically, this flag will turn the inner PMT and inner PMT shield orientation method to "point", which will point the PMTs at whatever point is defined in Watchman.geo.  Currently, the points are defined to point at [0,0,0], or world center.