### PR TITLE
Added a misssing letter in one of the names that resulted in a crash …

### DIFF
--- a/watchmakers/io_operations.py
+++ b/watchmakers/io_operations.py
@@ -1030,7 +1030,7 @@ def testEnabledCondition(arguments):
     if arguments['--pmtCtrPoint']:
         additionalMacOpt += '/rat/db/set GEO[inner_pmts] orientation "point"\n'
         additionalMacOpt += '/rat/db/set GEO[shield] orientation_inner "point"\n' 
-        additionaMacStr += "_pmtCtrPoint_"
+        additionalMacStr += "_pmtCtrPoint_"
         additionalString += "_pmtCtrPoint_"
 
     if float(arguments['--U238_PPM'])!= defaultValues[baseValue+15]:


### PR DESCRIPTION
…for center point.

I am having issues with this at the rat-pac level. The error I have is : 

GeoPMTArrayFactory: Constructing volume inner_pmts
DB: Field GEO[inner_pmts].orient_point lookup failure.  Does not exist or has wrong type.

Since this is not an issue with watchmakers, I am merging your changes.
